### PR TITLE
Update to serilog periodic batching 4.x

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,2 +1,2 @@
-bin\
-obj\
+bin/
+obj/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,10 @@
-FROM microsoft/dotnet:2.1-sdk AS build
-ADD . / 
+FROM mcr.microsoft.com/dotnet/sdk:6.0 AS build
+COPY . / 
 WORKDIR /sample/Sample
 RUN dotnet restore
-RUN dotnet publish -c Release -o out -f netcoreapp2.0
+RUN dotnet publish -c Release -o out -f net6.0
 
-FROM microsoft/dotnet:2.1-runtime AS runtime
+FROM mcr.microsoft.com/dotnet/runtime:6.0 AS runtime
 WORKDIR /sample/Sample
 COPY --from=build /sample/Sample/out ./
 ENTRYPOINT ["dotnet", "Sample.dll"]

--- a/build.sh
+++ b/build.sh
@@ -7,10 +7,11 @@ dotnet restore
 for path in src/**/Serilog.Sinks.Splunk.csproj; do
     dotnet build -f netstandard2.0 -c Release ${path}
     dotnet build -f netstandard2.1 -c Release ${path}
+    dotnet build -f net6.0 -c Release ${path}
 done
 
 for path in test/*.Tests/*.csproj; do
-    dotnet test -f net5.0  -c Release ${path}
+    dotnet test -f net6.0  -c Release ${path}
 done
 
-dotnet build -f net5.0 -c Release sample/Sample/Sample.csproj
+dotnet build -f net6.0 -c Release sample/Sample/Sample.csproj

--- a/sample/Sample/Sample.csproj
+++ b/sample/Sample/Sample.csproj
@@ -6,8 +6,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Serilog" Version="2.10.0" />
-    <PackageReference Include="Serilog.Sinks.Console" Version="4.0.0" />
+    <PackageReference Include="Serilog" Version="3.1.1" />
+    <PackageReference Include="Serilog.Sinks.Console" Version="5.0.1" />
     <PackageReference Include="Serilog.Settings.Configuration" Version="3.3.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="5.0.0" />
   </ItemGroup>

--- a/sample/Sample/Sample.csproj
+++ b/sample/Sample/Sample.csproj
@@ -2,14 +2,14 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="Serilog" Version="3.1.1" />
     <PackageReference Include="Serilog.Sinks.Console" Version="5.0.1" />
     <PackageReference Include="Serilog.Settings.Configuration" Version="3.3.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="5.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="6.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/sample/splunk/Dockerfile
+++ b/sample/splunk/Dockerfile
@@ -1,2 +1,2 @@
-FROM splunk/splunk:7.2
+FROM splunk/splunk:latest
 ADD etc ${SPLUNK_HOME}/etc

--- a/src/Serilog.Sinks.Splunk/Serilog.Sinks.Splunk.csproj
+++ b/src/Serilog.Sinks.Splunk/Serilog.Sinks.Splunk.csproj
@@ -4,7 +4,7 @@
     <Description>The Splunk Sink for Serilog</Description>
     <VersionPrefix>3.7.0</VersionPrefix>
     <Authors>Matthew Erbs, Serilog Contributors</Authors>
-    <TargetFrameworks>netstandard2.1;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.1;netstandard2.0;net6.0</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <AssemblyName>Serilog.Sinks.Splunk</AssemblyName>
     <PackageId>Serilog.Sinks.Splunk</PackageId>
@@ -18,11 +18,12 @@
     <PublicSign Condition=" '$(OS)' != 'Windows_NT' ">true</PublicSign>
     <SignAssembly>true</SignAssembly>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <RootNamespace>Serilog</RootNamespace>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Serilog" Version="2.10.0" />
-    <PackageReference Include="Serilog.Sinks.PeriodicBatching" Version="2.3.0" />
+    <PackageReference Include="Serilog" Version="3.1.1" />
+    <PackageReference Include="Serilog.Sinks.PeriodicBatching" Version="4.0.0" />
   </ItemGroup>
 
 </Project>

--- a/src/Serilog.Sinks.Splunk/Serilog.Sinks.Splunk.csproj
+++ b/src/Serilog.Sinks.Splunk/Serilog.Sinks.Splunk.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <Description>The Splunk Sink for Serilog</Description>
-    <VersionPrefix>3.7.0</VersionPrefix>
+    <VersionPrefix>4.0.0</VersionPrefix>
     <Authors>Matthew Erbs, Serilog Contributors</Authors>
     <TargetFrameworks>netstandard2.1;netstandard2.0;net6.0</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/test/Serilog.Sinks.Splunk.Tests/Serilog.Sinks.Splunk.Tests.csproj
+++ b/test/Serilog.Sinks.Splunk.Tests/Serilog.Sinks.Splunk.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <AssemblyName>Serilog.Sinks.Splunk.Tests</AssemblyName>
     <PackageId>Serilog.Sinks.Splunk.Tests</PackageId>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>


### PR DESCRIPTION
Updated Serilog and Serilog Periodic Batcher Dependencies to current version

The contract for serilog-periodic-batcher changed from a base class approach to a composition approach which requires changing the `EventCollectorSink` to support the new interface.
With the upgrade the target framework was matched to the target framework used by serilog-periodic-batcher.

Updated the target framework for the unit tests to match the target framework used by `serilog-periodic-batcher`

Additionally updated the tests, and sample Docker/compose. I've not been able to get it to run correctly, but it fails under the current dev version as well (at least on Fedora Linux 39)