### PR TITLE
Dotnet 8.0 updates

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,10 @@
-FROM mcr.microsoft.com/dotnet/sdk:6.0 AS build
-COPY . / 
+FROM microsoft/dotnet:8.0-sdk AS build
+ADD . / 
 WORKDIR /sample/Sample
 RUN dotnet restore
-RUN dotnet publish -c Release -o out -f net6.0
+RUN dotnet publish -c Release -o out -f net8.0
 
-FROM mcr.microsoft.com/dotnet/runtime:6.0 AS runtime
+FROM microsoft/dotnet:8.0-runtime AS runtime
 WORKDIR /sample/Sample
 COPY --from=build /sample/Sample/out ./
 ENTRYPOINT ["dotnet", "Sample.dll"]

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,7 +1,7 @@
 version: '{build}'
 skip_tags: true
 image:
-  - Visual Studio 2019
+  - Visual Studio 2022
   - Ubuntu2004
 configuration:
   - Release

--- a/build.sh
+++ b/build.sh
@@ -7,11 +7,10 @@ dotnet restore
 for path in src/**/Serilog.Sinks.Splunk.csproj; do
     dotnet build -f netstandard2.0 -c Release ${path}
     dotnet build -f netstandard2.1 -c Release ${path}
-    dotnet build -f net6.0 -c Release ${path}
 done
 
 for path in test/*.Tests/*.csproj; do
-    dotnet test -f net6.0  -c Release ${path}
+    dotnet test -f net8.0  -c Release ${path}
 done
 
-dotnet build -f net6.0 -c Release sample/Sample/Sample.csproj
+dotnet build -f net8.0 -c Release sample/Sample/Sample.csproj

--- a/sample/Sample/Program.cs
+++ b/sample/Sample/Program.cs
@@ -1,10 +1,10 @@
-﻿using System.Collections.Generic;
-using System.Linq;
-using System.IO;
+﻿using Microsoft.Extensions.Configuration;
 using Serilog;
 using Serilog.Sinks.Splunk;
-using Microsoft.Extensions.Configuration;
 using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
 
 namespace Sample
 {
@@ -18,7 +18,7 @@ namespace Sample
         public static void Main(string[] args)
         {
             // Bootstrap a simple logger.
-            var logger  = new LoggerConfiguration()
+            var logger = new LoggerConfiguration()
             .WriteTo.Console()
             .CreateLogger();
 
@@ -94,7 +94,6 @@ namespace Sample
             var configuration = new ConfigurationBuilder()
                 .SetBasePath(Directory.GetCurrentDirectory())
                 .AddJsonFile("appsettings.json")
-                .AddUserSecrets<Program>()
                 .Build();
 
             Log.Logger = new LoggerConfiguration()

--- a/sample/Sample/Sample.csproj
+++ b/sample/Sample/Sample.csproj
@@ -2,14 +2,14 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="Serilog" Version="3.1.1" />
     <PackageReference Include="Serilog.Sinks.Console" Version="5.0.1" />
-    <PackageReference Include="Serilog.Settings.Configuration" Version="3.3.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="6.0.0" />
+    <PackageReference Include="Serilog.Settings.Configuration" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="8.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Serilog.Sinks.Splunk/Serilog.Sinks.Splunk.csproj
+++ b/src/Serilog.Sinks.Splunk/Serilog.Sinks.Splunk.csproj
@@ -4,7 +4,7 @@
     <Description>The Splunk Sink for Serilog</Description>
     <VersionPrefix>4.0.0</VersionPrefix>
     <Authors>Matthew Erbs, Serilog Contributors</Authors>
-    <TargetFrameworks>netstandard2.1;netstandard2.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.1;netstandard2.0;net6.0;net8.0</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <AssemblyName>Serilog.Sinks.Splunk</AssemblyName>
     <PackageId>Serilog.Sinks.Splunk</PackageId>
@@ -24,7 +24,7 @@
 
   <ItemGroup>
     <PackageReference Include="Serilog" Version="3.1.1" />
-    <PackageReference Include="Serilog.Sinks.PeriodicBatching" Version="4.0.0" />
+    <PackageReference Include="Serilog.Sinks.PeriodicBatching" Version="4.0.1" />
   </ItemGroup>
 
 </Project>

--- a/src/Serilog.Sinks.Splunk/Sinks/Splunk/EventCollectorSink.cs
+++ b/src/Serilog.Sinks.Splunk/Sinks/Splunk/EventCollectorSink.cs
@@ -164,8 +164,11 @@ namespace Serilog.Sinks.Splunk
                 : new EventCollectorClient(eventCollectorToken);
         }
 
-        /// <inheritdoc />
-        public async Task EmitBatchAsync(IEnumerable<LogEvent> events)
+        /// <summary>
+        ///     Emit a batch of log events, running asynchronously.
+        /// </summary>
+        /// <param name="events">The events to emit.</param>
+        public virtual async Task EmitBatchAsync(IEnumerable<LogEvent> events)
         {
             var allEvents = new StringWriter();
 

--- a/src/Serilog.Sinks.TCP/Serilog.Sinks.Splunk.TCP.csproj
+++ b/src/Serilog.Sinks.TCP/Serilog.Sinks.Splunk.TCP.csproj
@@ -20,7 +20,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Serilog.Sinks.Splunk" Version="3.6.0" />
+    <PackageReference Include="Serilog.Sinks.Splunk" Version="3.7.0" />
     <PackageReference Include="Splunk.Logging.Common.Core" Version="1.0.0" />
   </ItemGroup>
 </Project>

--- a/src/Serilog.Sinks.UDP/Serilog.Sinks.Splunk.UDP.csproj
+++ b/src/Serilog.Sinks.UDP/Serilog.Sinks.Splunk.UDP.csproj
@@ -20,6 +20,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Serilog.Sinks.Splunk" Version="3.6.0" />
+    <PackageReference Include="Serilog.Sinks.Splunk" Version="3.7.0" />
   </ItemGroup>
 </Project>

--- a/test/Serilog.Sinks.Splunk.Tests/Serilog.Sinks.Splunk.Tests.csproj
+++ b/test/Serilog.Sinks.Splunk.Tests/Serilog.Sinks.Splunk.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <AssemblyName>Serilog.Sinks.Splunk.Tests</AssemblyName>
     <PackageId>Serilog.Sinks.Splunk.Tests</PackageId>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
@@ -15,14 +15,14 @@
   </PropertyGroup>
  
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.1" />
-    <PackageReference Include="xunit" Version="2.5.0" />
-      <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
-         <PackageReference Include="System.Net.Http" Version="4.3.4" />
-         <PackageReference Include="xunit.runner.visualstudio" Version="2.5.0">
-           <PrivateAssets>all</PrivateAssets>
-           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-         </PackageReference>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
+    <PackageReference Include="xunit" Version="2.7.0" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+    <PackageReference Include="System.Net.Http" Version="4.3.4" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.7">
+        <PrivateAssets>all</PrivateAssets>
+        <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />
   </ItemGroup>
 


### PR DESCRIPTION
This updates the project for dotnet 8.0 compatibility and switches the build to VS2022.

It also adds some more changes for the Serilog.Sinks.PeriodicBatching changes per https://github.com/serilog/serilog-sinks-periodicbatching/blob/dev/README.md

## Dependency Updates
- Serilog.Sinks.PeriodicBatching 4.0.1

Once a 4.0.0 build is available on Nuget, the src/Serilog.Sinks.UDP/Serilog.Sinks.Splunk.UDP.csproj and src/Serilog.Sinks.UDP/Serilog.Sinks.Splunk.TCP.csproj projects should be updated.

Fixes #169